### PR TITLE
Feature/read instance id from env

### DIFF
--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -42,6 +42,8 @@ spec:
                 secretKeyRef:
                   name: nifcloud-secret
                   key: secret_access_key
+            - name: NIFCLOUD_INSTANCE_ID
+              value: ""
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -34,6 +34,8 @@ spec:
               value: unix:/csi/csi.sock
             - name: NIFCLOUD_ZONE
               value: east-11
+            - name: NIFCLOUD_INSTANCE_ID
+              value: ""
           volumeMounts:
             - name: kubelet-dir
               mountPath: /var/lib/kubelet

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -41,7 +42,7 @@ type DriverOptions struct {
 func NewDriver(options ...func(*DriverOptions)) (*Driver, error) {
 	klog.Infof("Driver: %v Version: %v", DriverName, driverVersion)
 
-	instanceID, err := getInstanceIDFromGuestInfo()
+	instanceID, err := getInstanceID()
 	if err != nil {
 		panic(err)
 	}
@@ -106,6 +107,15 @@ func WithEndpoint(endpoint string) func(*DriverOptions) {
 	return func(o *DriverOptions) {
 		o.endpoint = endpoint
 	}
+}
+
+func getInstanceID() (string, error) {
+	instanceID := os.Getenv("NIFCLOUD_INSTANCE_ID")
+	if instanceID != "" {
+		return instanceID, nil
+	}
+
+	return getInstanceIDFromGuestInfo()
 }
 
 func getInstanceIDFromGuestInfo() (string, error) {


### PR DESCRIPTION
# Summary

- if `NIFCLOUD_INSTANCE_ID` environment variable was found, use it as instance identifier for controller and node driver.
